### PR TITLE
Upgrade pipx in windows-latest before running tests actions

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -2,5 +2,5 @@ pip==23.1
 pre-commit==3.2.2
 nox==2022.11.21
 nox-poetry==1.0.2
-poetry==1.4.2
+poetry==1.4.1
 virtualenv==20.21.1

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -2,5 +2,5 @@ pip==23.1
 pre-commit==3.2.2
 nox==2022.11.21
 nox-poetry==1.0.2
-poetry==1.4.1
+poetry==1.4.2
 virtualenv==20.21.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           pip install --constraint=.github/workflows/constraints.txt pip
           pip --version
+          pip install --upgrade pipx
 
       - name: Upgrade pip in virtual environments
         shell: python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           pip install --constraint=.github/workflows/constraints.txt pip
           pip --version
+          pipx --version
           pip install --upgrade pipx
 
       - name: Upgrade pip in virtual environments


### PR DESCRIPTION
Apparently the default version of pipx available in the python 3.10 windows image is not up-to-date.  This causes pip to fail resolving poetry as dependency. Updating pipx solves this. 

Solves #68